### PR TITLE
Default to no listening beep confirmation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -99,7 +99,7 @@ class Mark2(MycroftSkill):
         super().__init__('Mark2')
 
         self.settings['auto_brightness'] = False
-        self.settings['use_listening_beep'] = True
+        self.settings['use_listening_beep'] = False
 
         # System volume
         self.volume = 0.5


### PR DESCRIPTION
Defaults to no beep, but still configurable through web settings to have confirmation beep.