### PR TITLE
Fixes Error thrown on removing event that was not added since device …

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -312,7 +312,8 @@ class Mark2(MycroftSkill):
         draw_file(self.find_resource('6-intro.fb', 'ui'))
         time.sleep(15)
         draw_file(self.find_resource('mycroft.fb', 'ui'))
-        self.bus.remove('enclosure.mouth.text', self.handle_show_text)
+        if not is_paired(): 
+            self.bus.remove('enclosure.mouth.text', self.handle_show_text)
 
     def on_handler_audio_start(self, message):
         """Light up LED when speaking, show volume if requested"""


### PR DESCRIPTION
…is already paired

This was throwing an error since the event is not added when the device is already paired. We only add and then remove this event to show the pairing code. 