### PR TITLE
Missing import

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,7 @@
 import astral
 import time
 import arrow
-from subprocess import call,check_output, CalledProcessError
+from subprocess import call, check_output, CalledProcessError
 from pytz import timezone
 from datetime import datetime
 from collections import namedtuple

--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,7 @@
 import astral
 import time
 import arrow
-from subprocess import call, CalledProcessError
+from subprocess import call,check_output, CalledProcessError
 from pytz import timezone
 from datetime import datetime
 from collections import namedtuple


### PR DESCRIPTION
Not sure how I missed this when testing my last PR. `check_output` needed to be imported with removal of importing just the `subprocess` module.