### PR TITLE
Now that wakeword event is ~30ms earlier use that as listening trigger

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -163,7 +163,7 @@ class Mark2(MycroftSkill):
             self.bus.on('mycroft.ready', self.reset_face)
 
             # Handle the 'waking' visual
-            self.add_event('recognizer_loop:record_begin',
+            self.add_event('recognizer_loop:wakeword',
                            self.handle_listener_started)
             self.add_event('recognizer_loop:record_end',
                            self.handle_listener_ended)


### PR DESCRIPTION
PR #2367 makes it so that the `wakeword` event occurs about ~30ms before the `record_begin` and we can indicate to the user sooner that Mycroft has detected the wake word. 